### PR TITLE
feat: merge addresses from xave-contract-addresses to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halodao/halodao-contract-addresses",
-  "version": "0.0.38",
+  "version": "0.1.0",
   "description": "List of HaloDAO contract addresses across all chains",
   "repository": "https://github.com/HaloDAO/halodao-contract-addresses",
   "author": "HaloDAO Dev",

--- a/src/arb.ts
+++ b/src/arb.ts
@@ -2,7 +2,12 @@ import { AddressCollection, ZERO_ADDRESS } from './types'
 
 const tokens = {
   USDC: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
-  fxPHP: '0x3d147cD9aC957B2a5F968dE9d1c6B9d0872286a0'
+  fxPHP: '0x3d147cD9aC957B2a5F968dE9d1c6B9d0872286a0',
+  EURS: '0xD22a58f79e9481D1a88e00c343885A588b34b68B',
+  fakeUSDC: '0x9cFf4A10b6Fb163a4DF369AaFed9d95838222ca6', // fake mintable token
+  fakeFxPHP: '0x03612728266b82EF5dB751fbf15ea7F1370502eE', // fake mintable token
+  fakeXSGD: '0x6d934DcbA7F8e89713b4334147c03e76f30CE094', // fake mintable token
+  fakeEURS: '0xe42827D98C053b6e9c97E39BE8b611102E8c1805' // fake mintable token
 }
 
 const curves = {
@@ -12,6 +17,7 @@ const curves = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: ZERO_ADDRESS,
     RNBW: '0xA4b7999A1456A481FB0F2fa7E431b9B641A00770',
     xRNBW: '0x323C11843DEaEa9f13126FE33B86f6C5086DE138'
   },
@@ -32,14 +38,30 @@ const addresses: AddressCollection = {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
       genesis: [],
-      enabled: [],
+      enabled: [
+        {
+          assets: [tokens.fakeFxPHP, tokens.fakeUSDC],
+          address: '0x540C3126DF05CfB001eaEEBB08D1659439d02a95',
+          poolId:
+            '0x540c3126df05cfb001eaeebb08d1659439d02a9500020000000000000000007d'
+        },
+        {
+          assets: [tokens.fakeXSGD, tokens.fakeUSDC],
+          address: '0x8e13Acc4780f78d13E92a30b72DF526bE76561eF',
+          poolId:
+            '0x8e13acc4780f78d13e92a30b72df526be76561ef00020000000000000000007e'
+        }
+      ],
       disabled: []
     },
-    proportionalLiquidity: '0x8DB14E029399C4500614161867b8bFc1a2F74019',
-    assimilatorFactory: '0xEF7bC37B491363Cf0ea7914b470ed846D48321D7',
+    proportionalLiquidity: '0x3af74d19F50f24C75e4000Fe665d718387b1DA74',
+    assimilatorFactory: '0xB474537769c335BC96cB86DeC70E6C7F36b39b1e',
+    swapLibrary: '0xF82fd35163D1383e76ceD09c605DF5DB81439014',
     oracles: {
       USDC: '0x50834F3163758fcC1Df9973b6e91f0F0F0434aD3',
-      fxPHP: '0xfF82AAF635645fD0bcc7b619C3F28004cDb58574'
+      fxPHP: '0xfF82AAF635645fD0bcc7b619C3F28004cDb58574',
+      XSGD: '0xF0d38324d1F86a176aC727A4b0c43c9F9d9c5EB1',
+      EURS: '0xA14d53bC1F1c0F31B4aA3BD109344E5009051a84'
     }
   },
   tokens,

--- a/src/arbTestnet.ts
+++ b/src/arbTestnet.ts
@@ -11,6 +11,7 @@ const curves = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: ZERO_ADDRESS,
     RNBW: '0xfbBf11Ae3E8A4b6D9C866B3f16741D1641ccc4d5',
     xRNBW: '0xAe0429F26ed25c8Ad22D2582315Cc99aa5de8fF6'
   },
@@ -36,6 +37,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {
       USDC: '0xe020609A0C31f4F96dCBB8DF9882218952dD95c4',
       fxPHP: '0xF4764A9536B0ef7195ad3902c4Fc68eEc48f9C67'

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -22,6 +22,7 @@ const curves = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: '0xDdD46A4966a2197396BeFdF1d922569bf5F3163b',
     RNBW: '0x16D185d025bF592114D1A68f83085F36159f6CdA',
     xRNBW: '0xbcbfEac78133D1efe71Ba16D4F4221b9AD4bAd01'
   },
@@ -63,20 +64,34 @@ const addresses: AddressCollection = {
       enabled: [
         {
           assets: [tokens.fxPHP, tokens.USDC],
-          address: '0xe2094130f94CC23BDfe46FF0EF63A13899F4D708',
+          address: '0x7e3771D33E3731F790e6FCd8ca0a14B08d44a98d',
           poolId:
-            '0xe2094130f94cc23bdfe46ff0ef63a13899f4d7080002000000000000000007e9'
+            '0x7e3771d33e3731f790e6fcd8ca0a14b08d44a98d0002000000000000000008fd'
+        },
+        {
+          assets: [tokens.EURS, tokens.USDC],
+          address: '0xd98F5042648f304a150f4f9D054516e9125C8088',
+          poolId:
+            '0xd98f5042648f304a150f4f9d054516e9125c80880002000000000000000008fe'
+        },
+        {
+          assets: [tokens.CHF, tokens.USDC],
+          address: '0xAa33da6719A7F9181BEEb20a27f4464DF461E7e4',
+          poolId:
+            '0xaa33da6719a7f9181beeb20a27f4464df461e7e400020000000000000000096d'
         }
       ],
       disabled: []
     },
-    proportionalLiquidity: '0x0dEf4438AdEcedE57A861b0964c84a50C68eEaDe',
-    assimilatorFactory: '0x4c13F1E2397f083bbaCCB4E53325d5389845BE2e',
+    proportionalLiquidity: '0x000f891aD773aBE5548446b4528161563113566a',
+    assimilatorFactory: '0x5fF15655C1E9de73eA63465F2BCA0D1636318240',
+    swapLibrary: '0xc9A5DA4a6BD896dee1eaB92C75C41101e835dF2A',
     oracles: {
       USDC: '0x9211c6b3BF41A10F78539810Cf5c64e1BB78Ec60',
       fxPHP: '0x84fdC8dD500F29902C99c928AF2A91970E7432b6',
-      XSGD: '0x8CE3cAc0E6635ce04783709ca3CC4F5fc5304299',
-      EURS: '0x0c15Ab9A0DB086e062194c273CC79f41597Bbf13'
+      XSGD: '0xa5FC4B3757Ce2533087de51752D12d908E48FEEF', // Mock
+      EURS: '0x0c15Ab9A0DB086e062194c273CC79f41597Bbf13',
+      CHF: '0xed0616BeF04D374969f302a34AE4A63882490A8C'
     }
   },
   tokens,

--- a/src/lollidao.mainnet.ts
+++ b/src/lollidao.mainnet.ts
@@ -9,6 +9,7 @@ const curves = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: ZERO_ADDRESS,
     RNBW: ZERO_ADDRESS,
     xRNBW: ZERO_ADDRESS,
     LPOP: '0x6335A2E4a2E304401fcA4Fc0deafF066B813D055',
@@ -53,6 +54,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {}
   },
   tokens: {}

--- a/src/mainnet.ts
+++ b/src/mainnet.ts
@@ -25,6 +25,7 @@ const curves = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: '0x2c66D4a60F9dEcDDAb32856E2E50dd50926438E2',
     RNBW: '0xe94b97b6b43639e238c851a7e693f50033efd75c',
     xRNBW: '0x47BE779De87de6580d0548cde80710a93c502405'
   },
@@ -72,6 +73,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {}
   },
   tokens,

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -7,6 +7,7 @@ const tokens = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: ZERO_ADDRESS,
     RNBW: '0x18e7bDB379928A651f093ef1bC328889b33A560c',
     xRNBW: '0xc104e54803abA12f7a171a49DDC333Da39f47193'
   },
@@ -39,6 +40,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {
       USDC: '0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7',
       fxPHP: '0x218231089Bebb2A31970c3b77E96eCfb3BA006D1',

--- a/src/rinkeby.ts
+++ b/src/rinkeby.ts
@@ -11,6 +11,7 @@ const tokens = {
 
 const addresses: AddressCollection = {
   protocol: {
+    XAV: ZERO_ADDRESS,
     RNBW: '0x357bdb97FB9555bede5ed5201dBD15a8f3f6B7B8',
     xRNBW: '0xC1cFbAdE2df5fe70C18273F926553D9d2c8f944C'
   },
@@ -45,6 +46,7 @@ const addresses: AddressCollection = {
     },
     proportionalLiquidity: ZERO_ADDRESS,
     assimilatorFactory: ZERO_ADDRESS,
+    swapLibrary: ZERO_ADDRESS,
     oracles: {
       USDC: '0xa24de01df22b63d23Ebc1882a5E3d4ec0d907bFB',
       EURS: '0x78F9e60608bF48a1155b4B2A5e31F32318a1d85F'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ type Pool = {
 
 export type AddressCollection = {
   protocol: {
+    XAV: string
     RNBW: string
     xRNBW: string
     LPOP?: string
@@ -61,11 +62,13 @@ export type AddressCollection = {
     }
     proportionalLiquidity: string
     assimilatorFactory: string
+    swapLibrary: string
     oracles: {
       USDC?: string
       fxPHP?: string
       XSGD?: string
       EURS?: string
+      CHF?: string
     }
   }
   tokens: {
@@ -86,6 +89,8 @@ export type AddressCollection = {
     indexUSDC?: string
     fakeUSDC?: string
     fakeFxPHP?: string
+    fakeXSGD?: string
+    fakeEURS?: string
   }
   lendingMarket?: {
     protocol: {


### PR DESCRIPTION
Rationale:
It is getting difficult to maintain 2 repos for Halodao & Xave contract addresses:
- if you add a new test token address, it needs to be added/synced on the other repo
- on PR review, chances are we are verifying the same addresses we already verified before on the other repo

It makes more sense to combine these two repos into one to eliminate the problems above. 

Currently, `halodao-contract-addresses` is widely used (e.g. on `halodao-interface`, `lending-market-ui`, `xave-strats`, etc.) while only `xave-interface` is used only on `xave-contract-addresseses`

I suggest we deprecate `xave-contract-addresses`, and simply move over the Xave addresses we need over to this repo - this PR is the first step in doing so