### PR TITLE
chore: resync+cleanup amm-v1 addresses

### DIFF
--- a/src/arb.ts
+++ b/src/arb.ts
@@ -12,7 +12,8 @@ const tokens = {
 
 const curves = {
   HLP_fxPHP_USDC: '0x90B48Bb20048786b167473dfEeC443142D043CF7',
-  HLP_fxAUD_USDC: '0xD5AD9eed5c5f28D83933779CD7E677e112991f51'
+  HLP_fxAUD_USDC: '0xD5AD9eed5c5f28D83933779CD7E677e112991f51',
+  HLP_fxPHP_USDC_inactive: '0xF5bD24215Fc8581Eb1429bFbf28174F76f740314'
 }
 
 const addresses: AddressCollection = {
@@ -31,7 +32,7 @@ const addresses: AddressCollection = {
     curves: {
       all: curves,
       enabled: [curves.HLP_fxPHP_USDC, curves.HLP_fxAUD_USDC],
-      disabled: []
+      disabled: [curves.HLP_fxPHP_USDC_inactive]
     }
   },
   ammV2: {

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -12,12 +12,11 @@ const tokens = {
 }
 
 const curves = {
-  HLP_CHF_USDC: '0x02e673e79cE5122a3B83Afa9964637C259cb090F',
+  HLP_XSGD_USDC: '0x7Fb6Ac9B01dDbAb407f19c23370639913c741c81',
   HLP_EURS_USDC: '0xB8D93735647453a6138FC6449922A442f2Fd068B',
-  HLP_GBP_USDC: '0x7169866E13F58E045D77D5bE3d79ad8cCADC0fbF',
-  HLP_WETH_USDC: '0x184B1a8985316Ca061cC1e043Ec1C666f4A73A18',
-  HLP_XIDR_USDC: '0xEe1ab46877d1DeFE18bAfC749F32919dF6928a16',
-  HLP_XSGD_USDC: '0x7Fb6Ac9B01dDbAb407f19c23370639913c741c81'
+  HLP_CHF_USDC: '0x35Eeaf4243AdB81C421c18FfA19fd8A0f3B7F252',
+  HLP_CHF_USDC_inactive: '0x02e673e79cE5122a3B83Afa9964637C259cb090F',
+  HLP_GBP_USDC_inactive: '0x7169866E13F58E045D77D5bE3d79ad8cCADC0fbF'
 }
 
 const addresses: AddressCollection = {
@@ -36,7 +35,11 @@ const addresses: AddressCollection = {
     zap: '0x7F1A07fd07261BF1Ad778c88eA732273EC85940b',
     curves: {
       all: curves,
-      enabled: [curves.HLP_XSGD_USDC, curves.HLP_EURS_USDC],
+      enabled: [
+        curves.HLP_XSGD_USDC,
+        curves.HLP_EURS_USDC,
+        curves.HLP_CHF_USDC
+      ],
       disabled: []
     },
     assimilators: {
@@ -130,8 +133,8 @@ const addresses: AddressCollection = {
       uiHaloPoolDataProvider: '0x6Af1ffC2F20e54CDED0549CEde1ba6269A615717'
     },
     lpAssets: {
-      HLP_CHF_USDC: curves.HLP_CHF_USDC,
-      HLP_GBP_USDC: curves.HLP_GBP_USDC,
+      HLP_CHF_USDC: curves.HLP_CHF_USDC_inactive,
+      HLP_GBP_USDC: curves.HLP_GBP_USDC_inactive,
       HLP_XSGD_USDC: curves.HLP_XSGD_USDC
     },
     priceOracles: {

--- a/src/mainnet.ts
+++ b/src/mainnet.ts
@@ -50,13 +50,13 @@ const addresses: AddressCollection = {
       enabled: [
         curves.HLP_TCAD_USDC,
         curves.HLP_XSGD_USDC,
-        curves.HLP_TGBP_USDC,
-        curves.HLP_UST_USDC
+        curves.HLP_TGBP_USDC
       ],
       disabled: [
         curves.HLP_TAUD_USDC,
         curves.HLP_fxPHP_USDC,
-        curves.HLP_tagPHP_USDC
+        curves.HLP_tagPHP_USDC,
+        curves.HLP_UST_USDC
       ]
     },
     assimilators: {

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -5,6 +5,14 @@ const tokens = {
   fakeFxPHP: '0xe1Ca353a88a8822ed95293a7E76bd20eEA2ff662'
 }
 
+const curves = {
+  HLP_XSGD_USDC: '0x8123C64D6607412C7Ac9E880f12245ef22558b14',
+  HLP_TAGPHP_USDC: '0x6156f030B877344470BAC075a708d7E27602cc17',
+  HLP_WTGBP_USDC: '0xbF772a745533f6bAd97C58D2cb6B241eF7487242',
+  HLP_WTCAD_USDC: '0xaEad273bc7E17DD6951ceD3264B1dBa8A19114C2',
+  HLP_WTAUD_USDC: '0x95AB308bE1e209eB6FfdD3279B5ea71D365AD30B'
+}
+
 const addresses: AddressCollection = {
   protocol: {
     XAV: ZERO_ADDRESS,
@@ -19,15 +27,12 @@ const addresses: AddressCollection = {
     router: '0x26f2860cdeB7cC785eE5d59a5Efb2D0D3842C39D',
     zap: '0xA187b61e9F8f6E58bB0eB8D88cAda05710143Ce8',
     curves: {
-      all: {},
-      enabled: [
-        '0x6156f030B877344470BAC075a708d7E27602cc17', // tagPHP:USDC
-        '0x8123C64D6607412C7Ac9E880f12245ef22558b14' // XSGD:USDC
-      ],
+      all: curves,
+      enabled: [curves.HLP_XSGD_USDC, curves.HLP_TAGPHP_USDC],
       disabled: [
-        '0x95AB308bE1e209eB6FfdD3279B5ea71D365AD30B', // wTAUD:USDC
-        '0xaEad273bc7E17DD6951ceD3264B1dBa8A19114C2', // wTCAD:USDC
-        '0xbF772a745533f6bAd97C58D2cb6B241eF7487242' // wTGBP:USDC
+        curves.HLP_WTGBP_USDC,
+        curves.HLP_WTCAD_USDC,
+        curves.HLP_WTAUD_USDC
       ]
     }
   },


### PR DESCRIPTION
Major:
- Removed UST/USDC from mainnet enabled pools

Minor:
- Add inactive fxPHP/USDC pool in arb
- Add new CHF/USDC pool in kovan
- Cleanup of unused curve addresses on Kovan