### PR TITLE
Features/new kovan deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halodao/halodao-contract-addresses",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "List of HaloDAO contract addresses across all chains",
   "repository": "https://github.com/HaloDAO/halodao-contract-addresses",
   "author": "HaloDAO Dev",

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -69,20 +69,27 @@ const addresses: AddressCollection = {
       enabled: [
         {
           assets: [tokens.fxPHP, tokens.USDC],
-          address: '0xB45812F17ff4e5D02BBca8cBA282C13d4750aBa3',
+          address: '0xc6233C45D07D5b5a7438F7044A9D512c13234B77',
           poolId:
-            '0xb45812f17ff4e5d02bbca8cba282c13d4750aba30002000000000000000009e6'
+            '0xc6233c45d07d5b5a7438f7044a9d512c13234b770002000000000000000009fa'
+        },
+        {
+          assets: [tokens.XSGD, tokens.USDC],
+          address: '0xc1CbE9733B845d3ab7C4004B118003d5554Cf1d1',
+          poolId:
+            '0xc1cbe9733b845d3ab7c4004b118003d5554cf1d10002000000000000000009fd'
         }
       ],
       disabled: []
     },
-    fxPoolFactory: '0x16491c68A0C79bCE3E21C0af43C1D0461D7546f4',
-    proportionalLiquidity: '0x057548Aa2Ba1CFE1a5c89F8f1412C74337308d9F',
-    assimilatorFactory: '0xf2F62D05FECB259550A3c35534372B6d5Cc92829',
-    swapLibrary: '0x5Ce680FF2FA8cAFCf8f9a301D998ff5f4A0B7fd0',
+    fxPoolFactory: '0xC54c21F2f15ea03402a9d04ffc77844FF4f7e296',
+    proportionalLiquidity: '0xBea9e4cF645aAC52f72A50cF0648B57974F9Ad02',
+    assimilatorFactory: '0xDD0546342E48a35f5DE1f32c410120C850847233',
+    swapLibrary: '0x9E56018a5b903651AfD5E28357Dd78b06ca84B07',
     assimilators: {
-      USDC_USD: '0x68556F63eF4C51567e1d956D2A8a8e74495F20Cc',
-      fxPHP_USD: '0xd33b64D39B7c3A8fFbF6FB2F1De6b1a71E6f7273'
+      USDC_USD: '0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D',
+      fxPHP_USD: '0xe7FD8A06C79D5E1888B02B08E1a138E15C899061',
+      XSGD_USD: '0x1593362e55cB1271f4C6fe778eA0d07B746fDC90'
     },
     oracles: {
       USDC: '0x9211c6b3BF41A10F78539810Cf5c64e1BB78Ec60',


### PR DESCRIPTION
Post-audit kovan deployment (07/25/22)

Please see below for deployment log:

```
fxPHP:USDC

yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy kovan
? Specify base token fxPHP
? LP token name LP-fxPHP-USDC
? LP token symbol LP
? Protocol fee 0
? Fresh deploy? Yes
Deploying fxPHP:USDC pool to kovan...
Using gas price:  5000000014
> Deploying AssimilatorFactory...
┌─────────┬──────────────────────────────────────────────┐
│ (index) │                    Values                    │
├─────────┼──────────────────────────────────────────────┤
│ oracle  │ '0x9211c6b3BF41A10F78539810Cf5c64e1BB78Ec60' │
│  quote  │ '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │
└─────────┴──────────────────────────────────────────────┘
> AssimilatorFactory deployed at: 0xDD0546342E48a35f5DE1f32c410120C850847233
> USDC assimilator address: 0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D
> Checking if fxPHP assimilator is already deployed...
> Deploying fxPHP assimilator...
┌──────────────┬──────────────────────────────────────────────┐
│   (index)    │                    Values                    │
├──────────────┼──────────────────────────────────────────────┤
│     base     │ '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0' │
│ baseDecimals │                      18                      │
│    oracle    │ '0x84fdC8dD500F29902C99c928AF2A91970E7432b6' │
└──────────────┴──────────────────────────────────────────────┘
> fxPHP assimilator deployed at: 0xe7FD8A06C79D5E1888B02B08E1a138E15C899061
> ProportionalLiquidity deployed at: 0xBea9e4cF645aAC52f72A50cF0648B57974F9Ad02
> Swap Library deployed at: 0x9E56018a5b903651AfD5E28357Dd78b06ca84B07
> Deploying FxPoolFactory...
> FxPoolFactory successfully deployed at: 0xC54c21F2f15ea03402a9d04ffc77844FF4f7e296
> Deploying FxPool...
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│   (index)    │                      0                       │                      1                       │                    Values                    │
├──────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│     name     │                                              │                                              │               'LP-fxPHP-USDC'                │
│    symbol    │                                              │                                              │                     'LP'                     │
│     fee      │                                              │                                              │                     '0'                      │
│ vaultAddress │                                              │                                              │ '0xBA12222222228d8Ba445958a75a0704d566BF2C8' │
│ sortedAssets │ '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0' │ '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │                                              │
└──────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
> FxPool successfully deployed at: 0xc6233C45D07D5b5a7438F7044A9D512c13234B77
> Balancer vault pool id: [object Object]
> Initializing FxPool...
┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    (index)    │                                                                                                                                                                                                                     Values                                                                                                                                                                                                                      │
├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    assets     │ '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0,0xe7FD8A06C79D5E1888B02B08E1a138E15C899061,0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0,0xe7FD8A06C79D5E1888B02B08E1a138E15C899061,0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │
│ assetsWeights │                                                                                                                                                                                                     '500000000000000000,500000000000000000'                                                                                                                                                                                                     │
└───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
> FxPool initialized!
> Setting FxPool params...
> FxPool params set!
> Setting collector address...
> Collector address set!
> Verifying FxPool...
Nothing to compile
No need to generate any newer typings.
@openzeppelin/contracts/access/Ownable.sol:26:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
    constructor () internal {
    ^ (Relevant source part starts here and spans across multiple lines).

@openzeppelin/contracts/utils/Pausable.sol:32:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
    constructor () internal {
    ^ (Relevant source part starts here and spans across multiple lines).

@openzeppelin/contracts/utils/ReentrancyGuard.sol:38:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
    constructor () internal {
    ^ (Relevant source part starts here and spans across multiple lines).

Successfully submitted source code for contract
contracts/FXPool.sol:FXPool at 0xc6233C45D07D5b5a7438F7044A9D512c13234B77
for verification on Etherscan. Waiting for verification result...

Successfully verified contract FXPool on Etherscan.
https://kovan.etherscan.io/address/0xc6233C45D07D5b5a7438F7044A9D512c13234B77#code
✨  Done in 160.24s.





xSGD:USDC

yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy kovan
? Specify base token XSGD
? LP token name LP-xSGD-USDC
? LP token symbol LP
? Protocol fee 0
? Fresh deploy? No
Deploying XSGD:USDC pool to kovan...
Using gas price:  5000000014
> Reusing AssimilatorFactory at  0xDD0546342E48a35f5DE1f32c410120C850847233
> USDC assimilator address: 0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D
> Checking if XSGD assimilator is already deployed...
> XSGD assimilator is already deployed at 0x1593362e55cB1271f4C6fe778eA0d07B746fDC90
> Reusing ProportionalLiquidity at  0xBea9e4cF645aAC52f72A50cF0648B57974F9Ad02
Need to add Swap Library to halodao-contract-addresses
> Reusing Swap Library at  0x9E56018a5b903651AfD5E28357Dd78b06ca84B07
> Deploying FxPoolFactory...
> Reusing FXPoolFactory at  0xC54c21F2f15ea03402a9d04ffc77844FF4f7e296
> Deploying FxPool...
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│   (index)    │                      0                       │                      1                       │                    Values                    │
├──────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│     name     │                                              │                                              │                'LP-xSGD-USDC'                │
│    symbol    │                                              │                                              │                     'LP'                     │
│     fee      │                                              │                                              │                     '0'                      │
│ vaultAddress │                                              │                                              │ '0xBA12222222228d8Ba445958a75a0704d566BF2C8' │
│ sortedAssets │ '0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09' │ '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │                                              │
└──────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
> FxPool successfully deployed at: 0xc1CbE9733B845d3ab7C4004B118003d5554Cf1d1
> Balancer vault pool id: [object Object]
> Initializing FxPool...
┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    (index)    │                                                                                                                                                                                                                     Values                                                                                                                                                                                                                      │
├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    assets     │ '0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09,0x1593362e55cB1271f4C6fe778eA0d07B746fDC90,0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09,0x1593362e55cB1271f4C6fe778eA0d07B746fDC90,0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0xab44DF70796aC8ce84E2FE134b7e4F557e118c4D,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │
│ assetsWeights │                                                                                                                                                                                                     '500000000000000000,500000000000000000'                                                                                                                                                                                                     │
└───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
> FxPool initialized!
> Setting FxPool params...
> FxPool params set!
> Setting collector address...
> Collector address set!
> Verifying FxPool...
Nothing to compile
No need to generate any newer typings.
@openzeppelin/contracts/access/Ownable.sol:26:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
    constructor () internal {
    ^ (Relevant source part starts here and spans across multiple lines).

@openzeppelin/contracts/utils/Pausable.sol:32:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
    constructor () internal {
    ^ (Relevant source part starts here and spans across multiple lines).

@openzeppelin/contracts/utils/ReentrancyGuard.sol:38:5: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
    constructor () internal {
    ^ (Relevant source part starts here and spans across multiple lines).

Successfully submitted source code for contract
contracts/FXPool.sol:FXPool at 0xc1CbE9733B845d3ab7C4004B118003d5554Cf1d1
for verification on Etherscan. Waiting for verification result...

Successfully verified contract FXPool on Etherscan.
https://kovan.etherscan.io/address/0xc1CbE9733B845d3ab7C4004B118003d5554Cf1d1#code
✨  Done in 103.56s.