### PR TITLE
feat: added hToken address for xSGD:USDC LP token + all fxPools addresses

### DIFF
--- a/src/arb.ts
+++ b/src/arb.ts
@@ -38,6 +38,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      all: {},
       genesis: [],
       enabled: [
         {

--- a/src/arbTestnet.ts
+++ b/src/arbTestnet.ts
@@ -31,6 +31,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: ZERO_ADDRESS,
     pools: {
+      all: {},
       genesis: [],
       enabled: [],
       disabled: []

--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -58,6 +58,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      all: fxPools,
       genesis: [
         {
           assets: [tokens.WETH, tokens.USDC],
@@ -168,7 +169,8 @@ const addresses: AddressCollection = {
     },
     hTokens: {
       HLP_XSGD_USDC: '0xad7b437eB7D1CD9a2fFcc009c34E9ed5A4Cf0A22',
-      USDC: '0x0a4f3a725d7C10030d437d1f409f3d99B928bf97'
+      USDC: '0x0a4f3a725d7C10030d437d1f409f3d99B928bf97',
+      LP_XSGD_USDC: '0x0a4f3a725d7C10030d437d1f409f3d99B928bf97'
     },
     variableDebtTokens: {
       USDC: '0xC99AD035150433B35AeDdB4adf983CaB6675AF5f'

--- a/src/lollidao.mainnet.ts
+++ b/src/lollidao.mainnet.ts
@@ -48,6 +48,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: ZERO_ADDRESS,
     pools: {
+      all: {},
       genesis: [],
       enabled: [],
       disabled: []

--- a/src/mainnet.ts
+++ b/src/mainnet.ts
@@ -67,6 +67,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      all: {},
       genesis: [],
       enabled: [],
       disabled: []

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -39,6 +39,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      all: {},
       genesis: [],
       enabled: [],
       disabled: []

--- a/src/rinkeby.ts
+++ b/src/rinkeby.ts
@@ -21,6 +21,7 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
+      all: {},
       genesis: [],
       enabled: [
         {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,22 @@ export type AddressCollection = {
   ammV2: {
     vault: string
     pools: {
+      all: {
+        LP_CHF_USDC?: string
+        LP_EURS_USDC?: string
+        LP_GBP_USDC?: string
+        LP_WETH_USDC?: string
+        LP_XIDR_USDC?: string
+        LP_XSGD_USDC?: string
+        LP_TCAD_USDC?: string
+        LP_TGBP_USDC?: string
+        LP_UST_USDC?: string
+        LP_TAUD_USDC?: string
+        LP_fxPHP_USDC?: string
+        LP_tagPHP_USDC?: string
+        LP_LPHP_USDC?: string
+        LP_fxAUD_USDC?: string
+      }
       genesis: Pool[]
       enabled: Pool[]
       disabled: Pool[]
@@ -169,6 +185,7 @@ export type AddressCollection = {
     hTokens?: {
       HLP_XSGD_USDC?: string
       USDC?: string
+      LP_XSGD_USDC?: string
     }
     variableDebtTokens?: {
       USDC?: string


### PR DESCRIPTION
Htoken address for xSGD:USDC LP token came from here:
<img width="1485" alt="Screen Shot 2022-07-29 at 3 55 04 PM" src="https://user-images.githubusercontent.com/1032707/181712146-c27fff3f-f5be-43b5-9416-a2fbd0c2aedf.png">

