### PR TITLE
feat: updated matic addresses after official amm-v2 deployment

### DIFF
--- a/src/kovan.ts
+++ b/src/kovan.ts
@@ -88,10 +88,10 @@ const addresses: AddressCollection = {
       ],
       disabled: []
     },
-    fxPoolFactory: '0xFd144A8d7c3d67e9D61023F88336d83707896b5F',
-    proportionalLiquidity: '0xB570E74D9FC205667aE4E511bE25a0A3b16081e8',
-    assimilatorFactory: '0xB5c3237c17c588bAa28F9b8ef6543a7Ff654a8e4',
-    swapLibrary: '0x0d65350F0e83f67534bB0D4a8fb50b33FBE9D1AC',
+    fxPoolFactory: '0xFa3Ae6811beC0d5eAe2dA48F032Ed2d6dc3250CD',
+    proportionalLiquidity: '0x9E25F2EC62350C4E9Cc8e8aEa5e8754CE286ad13',
+    assimilatorFactory: '0x63D756041460C7A9e195391e39e12D298c628eAb',
+    swapLibrary: '0x11F236652df60085610AfFBa9C61Ba2A5F93Dfb3',
     assimilators: {
       USDC_USD: '0x79EE248FB0007905e42549B4574CfA48574e562a',
       fxPHP_USD: '0x0B6773500172cC07968Edb7D8884Fe500AA1cb3a',
@@ -176,7 +176,8 @@ const addresses: AddressCollection = {
       address: '0xC6b596068Ab44Cf1285972bC928e2cF82DD4b785',
       pool: {
         address: fxPools.LP_XSGD_USDC,
-        poolId: '0x56225362715133403a294a1c0f69f5d4e59b4dd8000200000000000000000a45',
+        poolId:
+          '0x56225362715133403a294a1c0f69f5d4e59b4dd8000200000000000000000a45',
         assets: [tokens.XSGD, tokens.USDC]
       }
     },

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -17,6 +17,10 @@ const curves = {
   HLP_WTAUD_USDC: '0x95AB308bE1e209eB6FfdD3279B5ea71D365AD30B'
 }
 
+const fxPools = {
+  LP_XSGD_USDC: '0x726E324c29a1e49309672b244bdC4Ff62A270407'
+}
+
 const addresses: AddressCollection = {
   protocol: {
     XAV: ZERO_ADDRESS,
@@ -43,15 +47,22 @@ const addresses: AddressCollection = {
   ammV2: {
     vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
     pools: {
-      all: {},
+      all: fxPools,
       genesis: [],
-      enabled: [],
+      enabled: [
+        {
+          assets: [tokens.XSGD, tokens.USDC],
+          address: fxPools.LP_XSGD_USDC,
+          poolId:
+            '0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702'
+        }
+      ],
       disabled: []
     },
-    fxPoolFactory: ZERO_ADDRESS,
-    proportionalLiquidity: ZERO_ADDRESS,
-    assimilatorFactory: ZERO_ADDRESS,
-    swapLibrary: ZERO_ADDRESS,
+    fxPoolFactory: '0x627D759314D5c4007b461A74eBaFA7EBC5dFeD71',
+    proportionalLiquidity: '0xe35A4e171F5568e8619DA1e097DAD18928187D85',
+    assimilatorFactory: '0x9CB3961ec9E54563602d96D2b3332028aa54dd13',
+    swapLibrary: '0x6256447F6dAa532d5A650cFeAf305D2DD7Bd296E',
     oracles: {
       USDC: '0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7',
       fxPHP: '0x218231089Bebb2A31970c3b77E96eCfb3BA006D1',


### PR DESCRIPTION
Updated amm-v2 addresses on latest matic & kovan deployments

# Matic deployment log

```
yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy matic
? Specify base token XSGD
? Protocol fee 0
? Fresh deploy? Yes
Deploying XSGD:USDC pool to matic...
Using gas price, limit:  38648865460 4000000
> Deploying AssimilatorFactory...
┌─────────┬──────────────────────────────────────────────┐
│ (index) │                    Values                    │
├─────────┼──────────────────────────────────────────────┤
│ oracle  │ '0xfE4A8cc5b5B2366C1B58Bea3858e81843581b2F7' │
│  quote  │ '0x2791bca1f2de4661ed88a30c99a7a9449aa84174' │
└─────────┴──────────────────────────────────────────────┘
> AssimilatorFactory deployed at: 0x9CB3961ec9E54563602d96D2b3332028aa54dd13
> USDC assimilator address: 0xfbdc1B9E50F8607E6649d92542B8c48B2fc49a1a
> Checking if XSGD assimilator is already deployed...
> Deploying XSGD assimilator...
┌──────────────┬──────────────────────────────────────────────┐
│   (index)    │                    Values                    │
├──────────────┼──────────────────────────────────────────────┤
│     base     │ '0xDC3326e71D45186F113a2F448984CA0e8D201995' │
│ baseDecimals │                      6                       │
│    oracle    │ '0x8CE3cAc0E6635ce04783709ca3CC4F5fc5304299' │
└──────────────┴──────────────────────────────────────────────┘
> XSGD assimilator deployed at: 0x0000000000000000000000000000000000000000
> ProportionalLiquidity deployed at: 0xe35A4e171F5568e8619DA1e097DAD18928187D85
> Swap Library deployed at: 0x6256447F6dAa532d5A650cFeAf305D2DD7Bd296E
> Deploying FxPoolFactory...
An unexpected error occurred:

Error: transaction failed [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ]





yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy matic
? Specify base token XSGD
? Protocol fee 0
? Fresh deploy? No
Deploying XSGD:USDC pool to matic...
Using gas price, limit:  72502618984 10000000
> Reusing AssimilatorFactory at  0x9CB3961ec9E54563602d96D2b3332028aa54dd13
> USDC assimilator address: 0xfbdc1B9E50F8607E6649d92542B8c48B2fc49a1a
> Checking if XSGD assimilator is already deployed...
> XSGD assimilator is already deployed at 0xb089a20e94Fd50Ce729981dE144b637324B44Ea4
> Reusing ProportionalLiquidity at  0xe35A4e171F5568e8619DA1e097DAD18928187D85
> Reusing Swap Library at  0x6256447F6dAa532d5A650cFeAf305D2DD7Bd296E
> Deploying FxPoolFactory...
> FxPoolFactory successfully deployed at: 0x627D759314D5c4007b461A74eBaFA7EBC5dFeD71
> Deploying FxPool...
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│   (index)    │                      0                       │                      1                       │                    Values                    │
├──────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│     name     │                                              │                                              │               'BPT-XSGD-USDC'                │
│    symbol    │                                              │                                              │                    'BPT'                     │
│     fee      │                                              │                                              │                     '0'                      │
│ vaultAddress │                                              │                                              │ '0xBA12222222228d8Ba445958a75a0704d566BF2C8' │
│ sortedAssets │ '0x2791bca1f2de4661ed88a30c99a7a9449aa84174' │ '0xDC3326e71D45186F113a2F448984CA0e8D201995' │                                              │
└──────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
An unexpected error occurred:

Error: missing revert data in call exception; Transaction reverted without a reason string 





yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy matic
? Specify base token XSGD
? Protocol fee 0
? Fresh deploy? No
Deploying XSGD:USDC pool to matic...
Using gas price, limit:  67914493870 10000000
> Reusing AssimilatorFactory at  0x9CB3961ec9E54563602d96D2b3332028aa54dd13
> USDC assimilator address: 0xfbdc1B9E50F8607E6649d92542B8c48B2fc49a1a
> Checking if XSGD assimilator is already deployed...
> XSGD assimilator is already deployed at 0xb089a20e94Fd50Ce729981dE144b637324B44Ea4
> Reusing ProportionalLiquidity at  0xe35A4e171F5568e8619DA1e097DAD18928187D85
Need to add Swap Library to halodao-contract-addresses
> Reusing Swap Library at  0x6256447F6dAa532d5A650cFeAf305D2DD7Bd296E
> Deploying FxPoolFactory...
> Reusing FXPoolFactory at  0x627D759314D5c4007b461A74eBaFA7EBC5dFeD71
> Deploying FxPool...
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│   (index)    │                      0                       │                      1                       │                    Values                    │
├──────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│     name     │                                              │                                              │               'BPT-XSGD-USDC'                │
│    symbol    │                                              │                                              │                    'BPT'                     │
│     fee      │                                              │                                              │                     '0'                      │
│ vaultAddress │                                              │                                              │ '0xBA12222222228d8Ba445958a75a0704d566BF2C8' │
│ sortedAssets │ '0x2791bca1f2de4661ed88a30c99a7a9449aa84174' │ '0xDC3326e71D45186F113a2F448984CA0e8D201995' │                                              │
└──────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
> FxPool successfully deployed at: 0x726E324c29a1e49309672b244bdC4Ff62A270407
> Balancer vault pool id: [object Object]
> Initializing FxPool...
┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    (index)    │                                                                                                                                                                                                                     Values                                                                                                                                                                                                                      │
├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    assets     │ '0xDC3326e71D45186F113a2F448984CA0e8D201995,0xb089a20e94Fd50Ce729981dE144b637324B44Ea4,0xDC3326e71D45186F113a2F448984CA0e8D201995,0xb089a20e94Fd50Ce729981dE144b637324B44Ea4,0xDC3326e71D45186F113a2F448984CA0e8D201995,0x2791bca1f2de4661ed88a30c99a7a9449aa84174,0xfbdc1B9E50F8607E6649d92542B8c48B2fc49a1a,0x2791bca1f2de4661ed88a30c99a7a9449aa84174,0xfbdc1B9E50F8607E6649d92542B8c48B2fc49a1a,0x2791bca1f2de4661ed88a30c99a7a9449aa84174' │
│ assetsWeights │                                                                                                                                                                                                     '500000000000000000,500000000000000000'                                                                                                                                                                                                     │
└───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
> FxPool initialized!
> Setting FxPool params...
> FxPool params set!
✨  Done in 18.80s
```

# Kovan deployment log

```
yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy kovan
? Specify base token XSGD
? Protocol fee 0
? Fresh deploy? Yes
Deploying XSGD:USDC pool to kovan...
Using gas price:  5000000014
> Deploying AssimilatorFactory...
┌─────────┬──────────────────────────────────────────────┐
│ (index) │                    Values                    │
├─────────┼──────────────────────────────────────────────┤
│ oracle  │ '0x9211c6b3BF41A10F78539810Cf5c64e1BB78Ec60' │
│  quote  │ '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │
└─────────┴──────────────────────────────────────────────┘
> AssimilatorFactory deployed at: 0x63D756041460C7A9e195391e39e12D298c628eAb
> USDC assimilator address: 0x3B151d531A1D748012Aa96926E2203C0181AFEeD
> Checking if XSGD assimilator is already deployed...
> Deploying XSGD assimilator...
┌──────────────┬──────────────────────────────────────────────┐
│   (index)    │                    Values                    │
├──────────────┼──────────────────────────────────────────────┤
│     base     │ '0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09' │
│ baseDecimals │                      6                       │
│    oracle    │ '0xa5FC4B3757Ce2533087de51752D12d908E48FEEF' │
└──────────────┴──────────────────────────────────────────────┘
> XSGD assimilator deployed at: 0x506D7c4705a91c8Fdc4b44fb01485f1603a3EceC
> ProportionalLiquidity deployed at: 0x9E25F2EC62350C4E9Cc8e8aEa5e8754CE286ad13
> Swap Library deployed at: 0x11F236652df60085610AfFBa9C61Ba2A5F93Dfb3
> Deploying FxPoolFactory...
> FxPoolFactory successfully deployed at: 0xFa3Ae6811beC0d5eAe2dA48F032Ed2d6dc3250CD
> Deploying FxPool...
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│   (index)    │                      0                       │                      1                       │                    Values                    │
├──────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│     name     │                                              │                                              │                'LP-XSGD-USDC'                │
│    symbol    │                                              │                                              │                     'LP'                     │
│     fee      │                                              │                                              │                     '0'                      │
│ vaultAddress │                                              │                                              │ '0xBA12222222228d8Ba445958a75a0704d566BF2C8' │
│ sortedAssets │ '0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09' │ '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │                                              │
└──────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
> FxPool successfully deployed at: 0x56225362715133403A294A1C0F69f5D4E59b4dd8
> Balancer vault pool id: [object Object]
> Initializing FxPool...
┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    (index)    │                                                                                                                                                                                                                     Values                                                                                                                                                                                                                      │
├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    assets     │ '0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09,0x506D7c4705a91c8Fdc4b44fb01485f1603a3EceC,0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09,0x506D7c4705a91c8Fdc4b44fb01485f1603a3EceC,0x4DCE1178D2A368397c09fc6C63e2f82F00a2Ca09,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0x3B151d531A1D748012Aa96926E2203C0181AFEeD,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0x3B151d531A1D748012Aa96926E2203C0181AFEeD,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │
│ assetsWeights │                                                                                                                                                                                                     '500000000000000000,500000000000000000'                                                                                                                                                                                                     │
└───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
> FxPool initialized!
> Setting FxPool params...
> FxPool params set!
> Verifying FxPool...
An unexpected error occurred:

TypeError: etherscan.apiKey.trim is not a function
    at SimpleTaskDefinition.verifySubtask [as action] (/Users/jamesrussellorola/Developer/xave/amm-contracts/node_modules/@nomiclabs/hardhat-etherscan/src/index.ts:159:58)
    at Environment._runTaskDefinition (/Users/jamesrussellorola/Developer/xave/amm-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:219:35)
    at Environment.run (/Users/jamesrussellorola/Developer/xave/amm-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:131:25)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:3:13
    at step (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:33:23)
    at Object.next (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:14:53)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:4:12)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:2:75
Error: Command failed: npx hardhat deploy-fx-pool --to kovan --basetoken XSGD --name LP-XSGD-USDC --symbol LP --fee 0 --fresh true --network kovan
    at checkExecSyncError (node:child_process:828:11)
    at Object.execSync (node:child_process:899:15)
    at runNpmCommand (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/cli/deployFxPoolCLI.ts:4:57)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/cli/deployFxPoolCLI.ts:38:12
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 99009,
  stdout: null,
  stderr: null
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

yarn deploy:fx-pool
yarn run v1.22.19
$ ts-node scripts/cli/deployFxPoolCLI.ts
? Which network to deploy kovan
? Specify base token fxPHP
? Protocol fee 0
? Fresh deploy? No
Deploying fxPHP:USDC pool to kovan...
Using gas price:  5000000014
> Reusing AssimilatorFactory at  0x63D756041460C7A9e195391e39e12D298c628eAb
> USDC assimilator address: 0x3B151d531A1D748012Aa96926E2203C0181AFEeD
> Checking if fxPHP assimilator is already deployed...
> Deploying fxPHP assimilator...
┌──────────────┬──────────────────────────────────────────────┐
│   (index)    │                    Values                    │
├──────────────┼──────────────────────────────────────────────┤
│     base     │ '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0' │
│ baseDecimals │                      18                      │
│    oracle    │ '0x84fdC8dD500F29902C99c928AF2A91970E7432b6' │
└──────────────┴──────────────────────────────────────────────┘
> fxPHP assimilator deployed at: 0xC33661d8B790C6EA201fa9dd49837AeefC33CCC9
> Reusing ProportionalLiquidity at  0x9E25F2EC62350C4E9Cc8e8aEa5e8754CE286ad13
Need to add Swap Library to halodao-contract-addresses
> Reusing Swap Library at  0x11F236652df60085610AfFBa9C61Ba2A5F93Dfb3
> Deploying FxPoolFactory...
> Reusing FXPoolFactory at  0xFa3Ae6811beC0d5eAe2dA48F032Ed2d6dc3250CD
> Deploying FxPool...
┌──────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┐
│   (index)    │                      0                       │                      1                       │                    Values                    │
├──────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┤
│     name     │                                              │                                              │               'LP-fxPHP-USDC'                │
│    symbol    │                                              │                                              │                     'LP'                     │
│     fee      │                                              │                                              │                     '0'                      │
│ vaultAddress │                                              │                                              │ '0xBA12222222228d8Ba445958a75a0704d566BF2C8' │
│ sortedAssets │ '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0' │ '0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │                                              │
└──────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┘
> FxPool successfully deployed at: 0x0E344Fa46db19CFc3924b51CdBDD8B94faF0cDbF
> Balancer vault pool id: [object Object]
> Initializing FxPool...
┌───────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    (index)    │                                                                                                                                                                                                                     Values                                                                                                                                                                                                                      │
├───────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    assets     │ '0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0,0xC33661d8B790C6EA201fa9dd49837AeefC33CCC9,0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0,0xC33661d8B790C6EA201fa9dd49837AeefC33CCC9,0x07bAB1e2D6DCb965d250F376B811ab8c2373AAE0,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0x3B151d531A1D748012Aa96926E2203C0181AFEeD,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE,0x3B151d531A1D748012Aa96926E2203C0181AFEeD,0x7e6F38922B59545bB5A6dc3A71039b85dFB1B7cE' │
│ assetsWeights │                                                                                                                                                                                                     '500000000000000000,500000000000000000'                                                                                                                                                                                                     │
└───────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
> FxPool initialized!
> Setting FxPool params...
> FxPool params set!
> Verifying FxPool...
An unexpected error occurred:

TypeError: etherscan.apiKey.trim is not a function
    at SimpleTaskDefinition.verifySubtask [as action] (/Users/jamesrussellorola/Developer/xave/amm-contracts/node_modules/@nomiclabs/hardhat-etherscan/src/index.ts:159:58)
    at Environment._runTaskDefinition (/Users/jamesrussellorola/Developer/xave/amm-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:219:35)
    at Environment.run (/Users/jamesrussellorola/Developer/xave/amm-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:131:25)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:3:13
    at step (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:33:23)
    at Object.next (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:14:53)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:4:12)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/utils/verify.ts:2:75
Error: Command failed: npx hardhat deploy-fx-pool --to kovan --basetoken fxPHP --name LP-fxPHP-USDC --symbol LP --fee 0 --fresh false --network kovan
    at checkExecSyncError (node:child_process:828:11)
    at Object.execSync (node:child_process:899:15)
    at runNpmCommand (/Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/cli/deployFxPoolCLI.ts:4:57)
    at /Users/jamesrussellorola/Developer/xave/amm-contracts/scripts/cli/deployFxPoolCLI.ts:38:12
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 99124,
  stdout: null,
  stderr: null
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.