### PR TITLE
Add lending market price oracle for bpt-xsgd-usdc in matic

### DIFF
--- a/src/matic.ts
+++ b/src/matic.ts
@@ -110,7 +110,7 @@ const addresses: AddressCollection = {
       LP_XSGD_USDC: fxPools.LP_XSGD_USDC
     },
     priceOracles: {
-      LP_XSGD_USDC: ''
+      LP_XSGD_USDC: '0xbca5c841eC9cC6Bd54ee18450eAe3B4D7b68146b'
     },
     hTokens: {
       LP_XSGD_USDC: '0xF2505AA3efAd1Fef6c36464329b50652ABC7e385',


### PR DESCRIPTION
To check:

1. Login to defender and go to Aave Oracle contract in Polygon -> https://defender.openzeppelin.com/#/admin/contracts/matic-0x0200889C2733bB78641126DF27A0103230452b62
2. Query the getSourceOfAsset function 
asset address: 0x726E324c29a1e49309672b244bdC4Ff62A270407