### PR TITLE
feat: separate older l2 gauge with new gauge by introducing a new type

### DIFF
--- a/src/matic.ts
+++ b/src/matic.ts
@@ -88,8 +88,11 @@ const addresses: AddressCollection = {
           poolId: poolIds.XSGD_USDC,
           gauges: {
             main: '0xe42382D005A620FaaA1B82543C9c04ED79Db03bA', // PolygonRootGauge
+            child: '0xa7165e1e3defe55dada5c4289268d57faba6dad2', // ChildLiquidityGauge
+
+            // deprecated as of June 2023 in favor of ChildLiquidityGauge (keeping it here for migration)
             l2: {
-              rewardsOnly: '0xa7165e1e3defe55dada5c4289268d57faba6dad2', // RewardsOnlyGauge
+              rewardsOnly: '0x3ac845345fc2d51a3006ed384055cd5acde86441', // RewardsOnlyGauge
               rewardsHelper: '0xaEb406b0E430BF5Ea2Dc0B9Fe62E4E53f74B3a33' // ChildChainGaugeRewardHelper
             }
           },

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -87,12 +87,12 @@ const addresses: AddressCollection = {
           address: fxPools.LP_XSGD_USDC,
           poolId: poolIds.XSGD_USDC,
           gauges: {
-            main: '0xe42382D005A620FaaA1B82543C9c04ED79Db03bA', // PolygonRootGauge
-            child: '0xa7165e1e3defe55dada5c4289268d57faba6dad2', // ChildLiquidityGauge
+            main: '0x145011e0C04805E11BEf23c1EEd848Faf49bB779', // PolygonRootGauge
+            child: '0xA7165E1E3dEfe55DAdA5C4289268d57faBA6dAd2', // ChildLiquidityGauge
 
             // deprecated as of June 2023 in favor of ChildLiquidityGauge (keeping it here for migration)
             l2: {
-              rewardsOnly: '0x3ac845345fc2d51a3006ed384055cd5acde86441', // RewardsOnlyGauge
+              rewardsOnly: '0x3aC845345fc2d51A3006Ed384055cD5ACde86441', // RewardsOnlyGauge
               rewardsHelper: '0xaEb406b0E430BF5Ea2Dc0B9Fe62E4E53f74B3a33' // ChildChainGaugeRewardHelper
             }
           },

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,9 @@ type Pool = {
   assets: string[]
   gauges?: {
     main: string // LiquidityGauge (Mainnet) | PolygonRootGauge (Polygon)
+    child?: string // ChildLiquidityGauge for L2s
+
+    // deprecated as of June 2023 in favor of ChildLiquidityGauge (keeping it here for migration)
     l2?: {
       rewardsOnly: string // RewardsOnlyGauge
       rewardsHelper: string // ChildChainGaugeRewardHelper


### PR DESCRIPTION
- reverted back Polygon XSGD:USDC gauge to the original RewardOnly gauge (https://polygonscan.com/address/0x3ac845345fc2d51a3006ed384055cd5acde86441#code)
- introduced new gauge type `child` where we added the new ChildLiquidityGauge gauge (https://polygonscan.com/address/0xa7165e1e3defe55dada5c4289268d57faba6dad2#code)
- new PolygonRootGauge for XSGD:USDC has also been introduced (https://etherscan.io/address/0x145011e0C04805E11BEf23c1EEd848Faf49bB779#readContract)

For more context - https://forum.balancer.fi/t/bip-262-l2-gauge-migration/4661