### PR TITLE
misc: hide veur/usdc on polygon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halodao/halodao-contract-addresses",
-  "version": "1.0.54",
+  "version": "1.0.55-beta-1",
   "description": "List of HaloDAO contract addresses across all chains",
   "repository": "https://github.com/HaloDAO/halodao-contract-addresses",
   "author": "HaloDAO Dev",

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -135,11 +135,6 @@ const addresses: AddressCollection = {
           assets: [tokens.VCHF, tokens.USDC],
           address: fxPools.LP_VCHF_USDC,
           poolId: poolIds.VCHF_USDC
-        },
-        {
-          assets: [tokens.VEUR, tokens.USDC],
-          address: fxPools.LP_VEUR_USDC,
-          poolId: poolIds.VEUR_USDC
         }
       ],
       disabled: [],
@@ -158,6 +153,11 @@ const addresses: AddressCollection = {
           assets: [tokens.XSGD, tokens['bb-a-usd']],
           address: fxPools['LP_XSGD_bb-a-usd'],
           poolId: poolIds['LP_XSGD_bb-a-usd']
+        },
+        {
+          assets: [tokens.VEUR, tokens.USDC],
+          address: fxPools.LP_VEUR_USDC,
+          poolId: poolIds.VEUR_USDC
         }
       ],
       ['bb-a-usd']: {


### PR DESCRIPTION
1.0.54 - both VCHF/USDC and VEUR/USDC Polygon are enabled
1.0.55 (this version) - hide VEUR/USDC Polygon