### PR TITLE
New liquidity rewards gauges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halodao/halodao-contract-addresses",
-  "version": "1.0.58",
+  "version": "1.0.59-beta-1",
   "description": "List of HaloDAO contract addresses across all chains",
   "repository": "https://github.com/HaloDAO/halodao-contract-addresses",
   "author": "HaloDAO Dev",

--- a/src/avalanche.ts
+++ b/src/avalanche.ts
@@ -57,17 +57,29 @@ const addresses: AddressCollection = {
         {
           assets: [tokens.EUROC, tokens.USDC],
           address: fxPools.LP_EUROC_USDC,
-          poolId: poolIds.EUROC_USDC
+          poolId: poolIds.EUROC_USDC,
+          gauges: {
+            main: ZERO_ADDRESS,
+            child: '0x35Ade969237697BA794bdDb9045aF06eDC96a47f'
+          }
         },
         {
           assets: [tokens.VEUR, tokens.USDC],
           address: fxPools.LP_VEUR_USDC,
-          poolId: poolIds.VEUR_USDC
+          poolId: poolIds.VEUR_USDC,
+          gauges: {
+            main: ZERO_ADDRESS,
+            child: '0xe41978AcA73F93BF67c27B60232449F2F4a29168'
+          }
         },
         {
           assets: [tokens.VCHF, tokens.USDC],
           address: fxPools.LP_VCHF_USDC,
-          poolId: poolIds.VCHF_USDC
+          poolId: poolIds.VCHF_USDC,
+          gauges: {
+            main: ZERO_ADDRESS,
+            child: '0xEB96333b3E0EFEf18A45d40C6144b78B0Dc70981'
+          }
         }
       ],
       disabled: [

--- a/src/mainnet.ts
+++ b/src/mainnet.ts
@@ -108,12 +108,18 @@ const addresses: AddressCollection = {
         {
           assets: [tokens.EURS, tokens.USDC],
           address: fxPools.LP_EURS_USDC,
-          poolId: fxPoolIds.EURS_USDC
+          poolId: fxPoolIds.EURS_USDC,
+          gauges: {
+            main: '0x008EB79DBE2Efcf8A9586F8F697464BE65D39eFf'
+          }
         },
         {
           assets: [tokens.GBPT, tokens.USDC],
           address: fxPools.LP_GBPT_USDC,
-          poolId: fxPoolIds.GBPT_USDC
+          poolId: fxPoolIds.GBPT_USDC,
+          gauges: {
+            main: '0x4a3d252d121c627F2450f06412Ca5c5A62e662f2'
+          }
         }
       ],
       disabled: [

--- a/src/matic.ts
+++ b/src/matic.ts
@@ -121,7 +121,12 @@ const addresses: AddressCollection = {
         {
           assets: [tokens.XSGD, tokens.USDC],
           address: fxPools.LP_XSGD_USDC,
-          poolId: poolIds.XSGD_USDC
+          poolId: poolIds.XSGD_USDC,
+          gauges: {
+            main: '0x2B7Bd050d7E0341fB49fF96f32eA59Bd8087d487',
+            child: '0x3DD7F73d807b7AA4A1112b30319201e9798D27C4'
+          },
+          rewardDistributor: '0x15308f419f141baf659160ADAC3255bff7f6B8C5'
         },
         {
           assets: [tokens.BRLA, tokens.USDC],


### PR DESCRIPTION
Changes:
- added new gauge addresses for our new fxpools
- added XSGD reward distributor address (reused contract) to XSGD/USDC Polygon

Gauge addresses is from this doc shared by @ctverceles :
https://docs.google.com/spreadsheets/d/18c71MXu1tQA8jrjIrdfLlLNBxi3PtJnv/edit?usp=sharing&ouid=101825255759536839656&rtpof=true&sd=true